### PR TITLE
Temp values from 1w have not padding zeros.

### DIFF
--- a/prometheus_temperature.py
+++ b/prometheus_temperature.py
@@ -72,7 +72,7 @@ def read_w1(onewire_temperature_c, sensor_mappings):
             therm_contents = therm_file.read()
             therm_file.seek(0)
 
-            m = re.search(r't=(-?\d{5})$', therm_contents)
+            m = re.search(r't=(-?\d+)$', therm_contents)
             if m:
                 temperature = (float(m.group(1)) / 1000)
                 # A reading of 85000 seems to mean "it's not working". If you actually want to


### PR DESCRIPTION
Prevents value freeze for temperatures below 10° (like now in France).